### PR TITLE
Small fixes to lein clean, and ui-only development

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -19,12 +19,12 @@
        :body (-> "public/index.html" io/resource slurp)})
    "public"))
 
-(defn start-ui! []
+(defn start-ui! [& [{:keys [ui-only?]}]]
   (figwheel-sidecar.repl-api/start-figwheel!
     (assoc-in (figwheel-sidecar.config/fetch-config)
       [:data :figwheel-options :ring-handler]
       'user/ui-handler)
-    "dev")
+    (if ui-only? "qa" "dev"))
   (figwheel-sidecar.repl-api/cljs-repl "dev"))
 
 (defn start-tests! []

--- a/project.clj
+++ b/project.clj
@@ -150,7 +150,7 @@
                                     ".cljs_node_repl"
                                     "dev-server/"
                                     "resources/public/css-compiled/"
-                                    "resources/public/js/"
+                                    "resources/public/js/compiled/"
                                     "server-tests/"
                                     "server/"
                                     "target/"]
@@ -161,7 +161,8 @@
                                   [figwheel-sidecar "0.5.18" :exclusions [org.clojure/core.async]]
                                   [org.clojure/clojure "1.9.0"]
                                   [org.clojure/tools.reader "1.3.0"]]
-                   :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
+                   :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]
+                                  :timeout 120000}
                    :source-paths ["dev" "src"]
                    :resource-paths ["resources"]}}
 


### PR DESCRIPTION
- lein clean was deleting the vendor js file, fixed it to only clean out compiled js files
- added a ui-only flag to `start-ui!` for ui only development
- Added a longer timeout for lein repl instantiation (was timing out)