### PR TITLE
Potential Fixes for Vote Input Button Issues

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -19,12 +19,12 @@
        :body (-> "public/index.html" io/resource slurp)})
    "public"))
 
-(defn start-ui! [& [{:keys [ui-only?]}]]
+(defn start-ui! []
   (figwheel-sidecar.repl-api/start-figwheel!
     (assoc-in (figwheel-sidecar.config/fetch-config)
       [:data :figwheel-options :ring-handler]
       'user/ui-handler)
-    (if ui-only? "qa" "dev"))
+    "dev")
   (figwheel-sidecar.repl-api/cljs-repl "dev"))
 
 (defn start-tests! []

--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,7 @@
   :plugins [[deraen/lein-less4clj "0.7.0-SNAPSHOT"]
             [lein-auto "0.1.2"]
             [lein-cljsbuild "1.1.7"]
-            [lein-figwheel "0.5.16"]
+            [lein-figwheel "0.5.18"]
             [lein-shell "0.5.0"]
             [lein-solc "1.0.2"]
             [lein-doo "0.1.8"]

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -42,7 +42,7 @@
       </div>
     </div>
     <script src="/js/compiled/app.js?v=1.0.3"></script>
-    <script src="./js/vendor/eth-ens-namehash.js"></script>
+    <script src="/js/vendor/eth-ens-namehash.js"></script>
     <script>district_registry.ui.core.init();</script>
   </body>
 


### PR DESCRIPTION
- Cleaned up disable vote button functionality to deal with null values better
- Removed :ui-only? from start-ui!, since it wasn't working
  - run as: `DISTRICT_REGISTRY_ENV=qa lein repl` instead
- Fixed index.html script srcs consistent (fixes client-side dev w- qa environment)

@madvas I suspect the `web3-utils/eth->wei` was causing issues when it was handed a null value. Was also experiencing issues with the `still-time-remaining?` always being false upon challenging, not sure if this is unrelated, since Alex's demo shows a time-remaining, which might explain why he could input, but the buttons continued to remain disabled.