### PR TITLE
Upgrade district-server-logging to 1.0.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [district0x/district-server-config "1.0.1"]
                  [district0x/district-server-db "1.0.4"]
                  [district0x/district-server-graphql "1.0.15"]
-                 [district0x/district-server-logging "1.0.5"]
+                 [district0x/district-server-logging "1.0.6"]
                  [district0x/district-server-middleware-logging "1.0.0"]
                  [district0x/district-server-smart-contracts "1.0.16"]
                  [district0x/district-server-web3 "1.0.1"]


### PR DESCRIPTION
Already upgraded  `/home/ubuntu/configs/registry.config.qa.edn` to 
```
{:logging {:level :info
           :console? true
           :file {:path "/logs/registry.qa.log"
                  :roll-daily? true}}
 ...
}

```