### PR TITLE
Update discord url

### DIFF
--- a/src/district_registry/ui/components/app_layout.cljs
+++ b/src/district_registry/ui/components/app_layout.cljs
@@ -61,7 +61,7 @@
         [:li [nav/a {:route [:route/privacy-policy]} "Privacy Policy"]]]]]
      [:div.col
       [:a.cta-btn.has-icon
-       {:href "https://discord.gg/rJvBEyV"
+       {:href "https://discord.com/invite/sS2AWYm"
         :target :_blank}
        [:span "Join Us On Discord"]
        [:span.icon-discord]]]


### PR DESCRIPTION
Update expired discord url to a new one: https://discord.com/invite/sS2AWYm

See this issue https://github.com/district0x/district-registry/issues/112