### PR TITLE
prevent reinitializing deployed Registry

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -48,6 +48,7 @@ contract Registry is DSAuth {
     external
   {
     require(address(_db) != 0x0, "Registry: Address can't be 0x0");
+    require(!wasConstructed);
     db = _db;
     wasConstructed = true;
     owner = msg.sender;


### PR DESCRIPTION
### Summary

Once a Registry is constructed, it must not allow calls to construct() any more.