### PR TITLE
Support for resumable migrations

### DIFF
--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require('path');
 const edn = require ("jsedn");
 const {contracts_build_directory} = require("../truffle.js");
 
@@ -119,6 +120,68 @@ kitDistrictAppsToNum = (apps) => {
   return apps.map((app) => kitDistrictAppToNum[app]);
 }
 
+class Status {
+  constructor(id) {
+    this.id = id;
+    this.currentStep = 0;
+    this.lastStep = -1;
+    this.values = {};
+    this._loadStatus();
+  }
+
+  async step(fn) {
+    if (this.lastStep < this.currentStep) {
+      console.log("Executing step: " + this.currentStep);
+      let values = await fn(this);
+      Object.assign(this.values, values);
+      this.lastStep++;
+      this._saveStatus();
+    } else {
+      console.log("Skipping previously executed step: " + this.currentStep);
+    }
+    this.currentStep++;
+  }
+
+  getValue(key) {
+    return this.values[key];
+  }
+
+  _filename() {
+    return path.resolve(__dirname, this.id + '_status.json');
+  }
+
+  _loadStatus() {
+    if (fs.existsSync(this._filename())) {
+      console.log("Previous execution detected. Loading status to resume")
+      try {
+        let data = fs.readFileSync(this._filename());
+        let st = JSON.parse(data.toString());
+        this.lastStep = st['lastStep'];
+        this.values = st['values'];
+      } catch (err) {
+        console.warn("Failed to load status");
+      }
+    }
+  }
+
+  _saveStatus() {
+    let data = JSON.stringify({'lastStep': this.lastStep, 'values': this.values});
+    try {
+      fs.writeFileSync(this._filename(), data)
+    } catch (err) {
+      console.warn("Cannot save state", err);
+    }
+  }
+
+  clean() {
+    try {
+      fs.unlinkSync(this._filename());
+    } catch (err) {
+      console.warn("Failed to clean status", err);
+    }
+  }
+}
+
 module.exports = {
   last: last,
   copy: copy,
@@ -131,5 +194,6 @@ module.exports = {
   writeSmartContracts: writeSmartContracts,
   getSmartContractAddress: getSmartContractAddress,
   setSmartContractAddress: setSmartContractAddress,
-  kitDistrictAppsToNum: kitDistrictAppsToNum
+  kitDistrictAppsToNum: kitDistrictAppsToNum,
+  Status: Status
 };


### PR DESCRIPTION
### Summary

Added support for resumable migrations.
The migration scripts can now be written in "steps" such that if one of the steps fails (e.g., if a transaction fails), next execution of the script will be resumed from the step which failed, that is, skipping all the previous (already executed) steps.
This way, gas is saved as it does not need to re-run all transactions from the beginning.

### Impl details

Note each step returns the state variables which are required in subsequent steps, and they are persisted in a temp file.
This has been applied to migration script 8.