### PR TITLE
Add legacy event and ens-name support for constructed districts

### DIFF
--- a/contracts/legacy/RegistryLegacy.sol
+++ b/contracts/legacy/RegistryLegacy.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.24;
+
+/**
+ Contract to support bringing legacy events after changing the event signature.
+ This will not be deployed to the blockchain, but just used for generating the contract descriptor such that
+ the events can be still searched using the old signature.
+*/
+contract RegistryLegacy {
+	event DistrictConstructedEvent(address registryEntry, uint version, address creator, bytes metaHash, uint deposit, uint challengePeriodEnd, address stakeBank, address aragonDao, string aragonId, uint timestamp);
+}

--- a/migrations/2_district_registry_migration.js
+++ b/migrations/2_district_registry_migration.js
@@ -190,6 +190,8 @@ async function deploy_DistrictRegistryForwarder(deployer, opts) {
   await dsGuard.permit(districtRegistryForwarder.address, districtRegistryDb.address, dsGuardANY, Object.assign({}, opts, {gas: 0.2e6}));
 
   assignContract(districtRegistryForwarder, "MutableForwarder", "district-registry-fwd", {forwardsTo: "district-registry"});
+  // keep this for legacy
+  assignContract(districtRegistryForwarder, "RegistryLegacy", "district-registry-legacy");
 }
 
 

--- a/src/district_registry/server/constants.cljs
+++ b/src/district_registry/server/constants.cljs
@@ -14,4 +14,6 @@
    :district-registry/vote-reward-claimed-event [:district-registry-fwd :VoteRewardClaimedEvent]
    :district-registry/challenger-reward-claimed-event [:district-registry-fwd :ChallengerRewardClaimedEvent]
    :district-registry/creator-reward-claimed-event [:district-registry-fwd :CreatorRewardClaimedEvent]
-   :district-registry/stake-changed-event [:district-registry-fwd :DistrictStakeChangedEvent]})
+   :district-registry/stake-changed-event [:district-registry-fwd :DistrictStakeChangedEvent]
+   :district-registry/district-legacy-constructed-event [:district-registry-legacy :DistrictConstructedEvent]
+   })

--- a/src/district_registry/server/db.cljs
+++ b/src/district_registry/server/db.cljs
@@ -44,7 +44,7 @@
    [:district/background-image-hash :string]
    [:district/dnt-staked :unsigned :BIG :INT not-nil]
    [:district/total-supply :unsigned :BIG :INT not-nil]
-   [:district/ens-name :string not-nil]
+   [:district/ens-name :string]
    [:district/stake-bank :string not-nil]
    [(sql/call :primary-key :reg-entry/address)]
    [(sql/call :foreign-key :reg-entry/address) (sql/call :references :reg-entries :reg-entry/address)]])

--- a/src/district_registry/shared/smart_contracts_dev.cljs
+++ b/src/district_registry/shared/smart_contracts_dev.cljs
@@ -101,4 +101,7 @@
     :address "0x0000000000000000000000000000000000000000"},
    :aragon/fifs-resolving-registrar
    {:name "FIFSResolvingRegistrar",
+    :address "0x0000000000000000000000000000000000000000"}
+   :district-registry-legacy
+   {:name "RegistryLegacy"
     :address "0x0000000000000000000000000000000000000000"}})

--- a/src/district_registry/shared/smart_contracts_prod.cljs
+++ b/src/district_registry/shared/smart_contracts_prod.cljs
@@ -65,4 +65,7 @@
     :address "0x5065ef0724b76421aeaafa87ba752d6c5d5499b5"}
    :district
    {:name "District"
-    :address "0x98aeac347318b7b63191828a4cb14F224CCDCF89"}})
+    :address "0x98aeac347318b7b63191828a4cb14F224CCDCF89"}
+   :district-registry-legacy
+   {:name "RegistryLegacy"
+    :address "0xf8d2c216aeeddabeb1c80a3560e56a20bda434dd"}})

--- a/src/district_registry/shared/smart_contracts_qa.cljs
+++ b/src/district_registry/shared/smart_contracts_qa.cljs
@@ -20,4 +20,5 @@
    :district-factory {:name "DistrictFactory" :address "0x40b47eb7da61e279f4f82d74b8ad239622343120"}
    :param-change-factory {:name "ParamChangeFactory" :address "0x6dc78010bb5b74db57f360a4a6b009013d6714a1"}
    :district0x-emails {:name "District0xEmails" :address "0xb4996f78c380e19a33703bd788270031849ba92b"}
+   :district-registry-legacy {:name "RegistryLegacy" :address "0x4e0505fe118c4187b07f2e99a5f8624e65afdad5"}
    })

--- a/src/district_registry/ui/edit/page.cljs
+++ b/src/district_registry/ui/edit/page.cljs
@@ -24,7 +24,8 @@
                                               :district/facebook-url
                                               :district/twitter-url
                                               :district/logo-image-hash
-                                              :district/background-image-hash]]]}])
+                                              :district/background-image-hash
+                                              :district/ens-name]]]}])
             {:keys [:reg-entry/address
                     :district/name
                     :district/description
@@ -33,7 +34,8 @@
                     :district/logo-image-hash
                     :district/background-image-hash
                     :district/facebook-url
-                    :district/twitter-url]} (:district results)]
+                    :district/twitter-url
+                    :district/ens-name]} (:district results)]
         [app-layout
          (when (seq name)
            [district-form {:edit? true
@@ -45,4 +47,5 @@
                                        :facebook-url facebook-url
                                        :twitter-url twitter-url
                                        :district/logo-image-hash logo-image-hash
-                                       :district/background-image-hash background-image-hash}}])]))))
+                                       :district/background-image-hash background-image-hash
+                                       :ens-name ens-name}}])]))))

--- a/src/district_registry/ui/events.cljs
+++ b/src/district_registry/ui/events.cljs
@@ -76,7 +76,8 @@
         :url
         :github-url
         :facebook-url
-        :twitter-url]
+        :twitter-url
+        :ens-name]
     (select-keys data)
     (medley/remove-vals nil?)
     (medley/map-vals safe-trim)


### PR DESCRIPTION
### Summary

Background: When starting the server, it fetches all the events from the blockchain produced by District Registry contracts to build up the DB. We specify the contracts and events to listen, from which it builds an event filter, to only get those.

Problem: Since the signature of the event DistrictConstructedEvent (Registry.sol) was changed, it was not bringing the old events. To build the event filter, it does not only use the event name, but the "topics", which is a hash of the signature of the event definition. In other words, when fetching the events, we are missing the old DistrictConstructedEvents because we are looking for a different event signature.

Solution: Create a fake contract (RegistryLegacy.sol) only defining the legacy event signature and use this contract description to bring the old events. We don't need to deploy this contract to the blockchain, but just make it so truffle compiles it. Then, adding an entry to the smart_contracts_xxx.cljs so we can use it in the syncer when fetching the events.

Additionally, functionality to set ens-name for existing districts have been added, so they can also use integration with Snapshot.